### PR TITLE
Movido calendario en formato texto al README.md

### DIFF
--- a/Material a evaluar en cada Clase.txt
+++ b/Material a evaluar en cada Clase.txt
@@ -1,7 +1,0 @@
-M10 - 03: 1-OOP_A
-J12 - 03: 2-Herencia-Multiherencia
-M17 - 03: 3-Polimorfismo + 4-Properties
-J19 - 03:
-M24 - 03:
-J26 - 03:
-M31 - 03:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ## Tabla de contenidos
+* [Calendario](#calendario)
+	* [Marzo](#marzo) 
 * [Programa](#programa)
     * [Equipo](#equipo)
     	* [Profesores](#profesores)
@@ -15,6 +17,19 @@
 * [Foro](#foro)
     * [Etiquetas](#etiquetas)
     * [Procedimiento](#procedimiento)
+
+# Calendario
+
+### Marzo
+| Día  | Contenido              	|
+|:-----|:------------------------------	|
+| M 10 | OOP				|
+| J 12 | Herencia & multiherencia	|
+| M 17 | Polimorfismo & properties	|
+| J 19 | 				|
+| M 24 | 				|
+| J 26 | 				|
+| M 31 | 				|
 
 # Programa
 


### PR DESCRIPTION
El archivo `Material a evaluar en cada Clase.txt` subido por @bcsaldias se ha movido al `README.md` para que sea más accesible para los alumnos. 
